### PR TITLE
Update api.py

### DIFF
--- a/backend/api.py
+++ b/backend/api.py
@@ -17,21 +17,15 @@ cache: Union[Cache, None] = None
 
 def _stats() -> Union[Dict[str, Union[str, int]], None]:
     req_mode_map = requests.get(CTF_API)
-    req_players = requests.get(SERVER_LIST_API)
 
-    if req_mode_map.ok and req_players.ok:
+    if req_mode_map.ok:
         j1 = req_mode_map.json()
-        j2 = [
-            x
-            for x in req_players.json()["list"]
-            if x["address"] == "ctf.rubenwardy.com"
-        ][0]
-        
+
         return {
             "map_technical": j1["current_map"]["technical_name"],
             "map": j1["current_map"]["name"],
             "mode": j1["current_mode"]["name"],
-            "players": j2["clients"],
+            "players": j1["player_info"]['count'],
             "start_time": j1["current_map"]["start_time"]
         }
     else:
@@ -47,5 +41,5 @@ def stats() -> Union[Dict[str, Union[str, int]], None]:
             time.sleep(.2)
         cache = Cache(expire=int(time.time() + CACHE_TIMEOUT), result=result)
         return result
-    
+
     return cache.result


### PR DESCRIPTION
Changed method to get player count from minetest serverlist api (which has an update delay of up to 5 minutes) to ctf api (which I believe has an update time of 30 seconds). This will also increase the performance as it will only need one, much smaller, request.